### PR TITLE
Add Watch Together Discord bot (TypeScript)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DISCORD_TOKEN=your-bot-token
+CLIENT_ID=your-application-client-id

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm install --omit=dev
+
+COPY . .
+RUN npm run build
+
+CMD ["node", "dist/bot.js"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# Watch Together Discord Bot
+
+Бот создаёт invite-ссылку на официальную Discord Activity **Watch Together (YouTube)** в текущем voice-канале.
+
+## Возможности
+
+- Только slash-команды.
+- `/yt start` — создаёт invite в voice-канале пользователя.
+- `/yt help` — краткая справка.
+- `/yt link <url>` — проверка ссылки youtube.com/youtu.be и подсказка для вставки в Watch Together.
+- Проверки: команда только в guild, пользователь в voice-канале, права **Create Instant Invite**, cooldown 10 секунд.
+
+## Требования
+
+- Node.js 20+
+- Discord.js v14+
+
+## Быстрый старт (локально)
+
+1. **Создай Discord Application** в [Discord Developer Portal](https://discord.com/developers/applications).
+2. Во вкладке **Bot** нажми **Add Bot**.
+3. Включи **Message Content Intent** не требуется (не используется), достаточно стандартных intents.
+4. Скопируй **Bot Token**.
+5. Скопируй **Client ID** приложения (в разделе **General Information**).
+6. Создай `.env` по примеру:
+
+```bash
+cp .env.example .env
+```
+
+Заполни:
+
+```
+DISCORD_TOKEN=...
+CLIENT_ID=...
+```
+
+7. Установи зависимости и запусти:
+
+```bash
+npm install
+npm run dev
+```
+
+При старте бот зарегистрирует slash-команды глобально.
+
+## Приглашение бота на сервер
+
+Сгенерируй ссылку:
+
+```
+https://discord.com/api/oauth2/authorize?client_id=YOUR_CLIENT_ID&permissions=1048576&scope=bot%20applications.commands
+```
+
+Разрешение `1048576` — **Create Instant Invite**. Убедись, что бот имеет это право в нужных voice-каналах.
+
+## Команды
+
+- `/yt start` — создать invite на Watch Together.
+- `/yt help` — справка.
+- `/yt link <url>` — проверка ссылки и подсказка.
+
+## Сборка и запуск
+
+```bash
+npm run build
+npm start
+```
+
+## Деплой
+
+- Используй любой Node.js 20+ хостинг.
+- Укажи переменные окружения `DISCORD_TOKEN` и `CLIENT_ID`.
+- Запусти `npm run build` и `npm start`.
+
+## Docker
+
+```bash
+docker compose up --build
+```
+
+Убедись, что файл `.env` находится рядом с `docker-compose.yml`.
+
+## Важно
+
+Бот **не** скачивает видео или аудио с YouTube. Он создаёт официальный invite на Discord Activity Watch Together.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.9"
+services:
+  bot:
+    build: .
+    env_file:
+      - .env
+    restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "watch-together-bot",
+  "version": "1.0.0",
+  "description": "Discord bot for creating Watch Together activity invites",
+  "main": "dist/bot.js",
+  "scripts": {
+    "dev": "tsx src/bot.ts",
+    "build": "tsc",
+    "start": "node dist/bot.js"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "discord.js": "^14.19.3",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,0 +1,96 @@
+import {
+  ChatInputCommandInteraction,
+  Client,
+  GatewayIntentBits,
+  Interaction,
+  REST,
+  Routes,
+  SlashCommandBuilder,
+  SlashCommandSubcommandBuilder
+} from "discord.js";
+import { config, validateConfig } from "./config";
+import * as ytStart from "./commands/ytStart";
+import * as ytHelp from "./commands/ytHelp";
+import * as ytLink from "./commands/ytLink";
+
+interface Subcommand {
+  name: string;
+  build: (subcommand: SlashCommandSubcommandBuilder) => SlashCommandSubcommandBuilder;
+  execute: (interaction: ChatInputCommandInteraction) => Promise<void>;
+}
+
+const subcommands: Subcommand[] = [ytStart, ytHelp, ytLink];
+
+const ytCommand = new SlashCommandBuilder()
+  .setName("yt")
+  .setDescription("Watch Together commands");
+
+subcommands.forEach((subcommand) => {
+  ytCommand.addSubcommand((builder) => subcommand.build(builder));
+});
+
+async function registerCommands(): Promise<void> {
+  const rest = new REST({ version: "10" }).setToken(config.token);
+  await rest.put(Routes.applicationCommands(config.clientId), {
+    body: [ytCommand.toJSON()]
+  });
+  console.log("Slash commands registered.");
+}
+
+async function main(): Promise<void> {
+  validateConfig();
+
+  const client = new Client({
+    intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildVoiceStates]
+  });
+
+  client.once("ready", () => {
+    console.log(`Logged in as ${client.user?.tag}`);
+  });
+
+  client.on("interactionCreate", async (interaction: Interaction) => {
+    if (!interaction.isChatInputCommand()) {
+      return;
+    }
+
+    if (interaction.commandName !== "yt") {
+      return;
+    }
+
+    const subcommandName = interaction.options.getSubcommand();
+    const handler = subcommands.find((sub) => sub.name === subcommandName);
+
+    if (!handler) {
+      await interaction.reply({
+        content: "Неизвестная подкоманда.",
+        ephemeral: true
+      });
+      return;
+    }
+
+    try {
+      await handler.execute(interaction);
+    } catch (error) {
+      console.error("Command execution error", error);
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({
+          content: "Произошла ошибка при выполнении команды.",
+          ephemeral: true
+        });
+      } else {
+        await interaction.reply({
+          content: "Произошла ошибка при выполнении команды.",
+          ephemeral: true
+        });
+      }
+    }
+  });
+
+  await registerCommands();
+  await client.login(config.token);
+}
+
+main().catch((error) => {
+  console.error("Startup error", error);
+  process.exit(1);
+});

--- a/src/commands/ytHelp.ts
+++ b/src/commands/ytHelp.ts
@@ -1,0 +1,26 @@
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  SlashCommandSubcommandBuilder
+} from "discord.js";
+
+export const name = "help";
+
+export function build(subcommand: SlashCommandSubcommandBuilder): SlashCommandSubcommandBuilder {
+  return subcommand
+    .setName(name)
+    .setDescription("Краткая справка по Watch Together");
+}
+
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  const embed = new EmbedBuilder()
+    .setTitle("Watch Together — помощь")
+    .setDescription(
+      "Команды:\n" +
+        "• /yt start — создать invite в твой voice-канал.\n" +
+        "• /yt link <url> — проверить ссылку на YouTube и отправить подсказку."
+    )
+    .setColor(0x5865f2);
+
+  await interaction.reply({ embeds: [embed], ephemeral: true });
+}

--- a/src/commands/ytLink.ts
+++ b/src/commands/ytLink.ts
@@ -1,0 +1,44 @@
+import {
+  ChatInputCommandInteraction,
+  SlashCommandSubcommandBuilder
+} from "discord.js";
+
+export const name = "link";
+
+export function build(subcommand: SlashCommandSubcommandBuilder): SlashCommandSubcommandBuilder {
+  return subcommand
+    .setName(name)
+    .setDescription("Проверить YouTube ссылку и отправить подсказку")
+    .addStringOption((option) =>
+      option
+        .setName("url")
+        .setDescription("Ссылка на youtube.com или youtu.be")
+        .setRequired(true)
+    );
+}
+
+function isValidYouTubeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.replace(/^www\./, "");
+    return hostname === "youtube.com" || hostname === "youtu.be";
+  } catch {
+    return false;
+  }
+}
+
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  const url = interaction.options.getString("url", true);
+
+  if (!isValidYouTubeUrl(url)) {
+    await interaction.reply({
+      content: "Пожалуйста, укажи корректную ссылку youtube.com или youtu.be.",
+      ephemeral: true
+    });
+    return;
+  }
+
+  await interaction.reply({
+    content: `Вот ссылка: ${url}\nВставь её в Watch Together для совместного просмотра.`
+  });
+}

--- a/src/commands/ytStart.ts
+++ b/src/commands/ytStart.ts
@@ -1,0 +1,100 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ChannelType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  GuildMember,
+  InviteTargetType,
+  SlashCommandSubcommandBuilder
+} from "discord.js";
+import { canCreateInvite } from "../lib/permissions";
+import { getRemainingCooldown, isOnCooldown, setCooldown } from "../lib/cooldown";
+
+const COOLDOWN_MS = 10_000;
+
+export const name = "start";
+
+export function build(subcommand: SlashCommandSubcommandBuilder): SlashCommandSubcommandBuilder {
+  return subcommand
+    .setName(name)
+    .setDescription("Создать Watch Together invite для текущего voice-канала");
+}
+
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  if (!interaction.inGuild()) {
+    await interaction.reply({
+      content: "Эта команда доступна только на сервере.",
+      ephemeral: true
+    });
+    return;
+  }
+
+  const member = interaction.member as GuildMember;
+  const voiceChannel = member.voice.channel;
+
+  if (!voiceChannel ||
+    (voiceChannel.type !== ChannelType.GuildVoice && voiceChannel.type !== ChannelType.GuildStageVoice)
+  ) {
+    await interaction.reply({
+      content: "Подключись к voice-каналу, чтобы создать Watch Together.",
+      ephemeral: true
+    });
+    return;
+  }
+
+  if (isOnCooldown(member.id, COOLDOWN_MS)) {
+    const remaining = Math.ceil(getRemainingCooldown(member.id, COOLDOWN_MS) / 1000);
+    await interaction.reply({
+      content: `Подожди ${remaining} сек. перед повторным использованием /yt start.`,
+      ephemeral: true
+    });
+    return;
+  }
+
+  const me = interaction.guild?.members.me;
+  if (!me) {
+    await interaction.reply({
+      content: "Не удалось определить права бота.",
+      ephemeral: true
+    });
+    return;
+  }
+
+  if (!canCreateInvite(voiceChannel, me)) {
+    await interaction.reply({
+      content: "Мне нужно право Create Instant Invite в этом voice-канале.",
+      ephemeral: true
+    });
+    return;
+  }
+
+  setCooldown(member.id);
+
+  const invite = await voiceChannel.createInvite({
+    maxAge: 3600,
+    maxUses: 0,
+    targetType: InviteTargetType.EmbeddedApplication,
+    targetApplication: "880218394199220334",
+    reason: `Watch Together requested by ${interaction.user.tag}`
+  });
+
+  const embed = new EmbedBuilder()
+    .setTitle("Watch Together")
+    .setDescription("Нажми кнопку ниже, чтобы открыть YouTube Activity.")
+    .setColor(0xff0000)
+    .addFields({
+      name: "Канал",
+      value: voiceChannel.name
+    });
+
+  const button = new ButtonBuilder()
+    .setLabel("Open Watch Together")
+    .setStyle(ButtonStyle.Link)
+    .setURL(invite.url);
+
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(button);
+
+  await interaction.reply({ embeds: [embed], components: [row] });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,12 @@
+import "dotenv/config";
+
+export const config = {
+  token: process.env.DISCORD_TOKEN ?? "",
+  clientId: process.env.CLIENT_ID ?? ""
+};
+
+export function validateConfig(): void {
+  if (!config.token || !config.clientId) {
+    throw new Error("Missing DISCORD_TOKEN or CLIENT_ID in environment.");
+  }
+}

--- a/src/lib/cooldown.ts
+++ b/src/lib/cooldown.ts
@@ -1,0 +1,19 @@
+const cooldowns = new Map<string, number>();
+
+export function isOnCooldown(userId: string, cooldownMs: number): boolean {
+  const lastUsed = cooldowns.get(userId);
+  if (!lastUsed) {
+    return false;
+  }
+  return Date.now() - lastUsed < cooldownMs;
+}
+
+export function setCooldown(userId: string): void {
+  cooldowns.set(userId, Date.now());
+}
+
+export function getRemainingCooldown(userId: string, cooldownMs: number): number {
+  const lastUsed = cooldowns.get(userId) ?? 0;
+  const remaining = cooldownMs - (Date.now() - lastUsed);
+  return Math.max(0, remaining);
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,13 @@
+import {
+  GuildBasedChannel,
+  GuildMember,
+  PermissionsBitField
+} from "discord.js";
+
+export function canCreateInvite(channel: GuildBasedChannel, member: GuildMember): boolean {
+  const permissions = channel.permissionsFor(member);
+  if (!permissions) {
+    return false;
+  }
+  return permissions.has(PermissionsBitField.Flags.CreateInstantInvite);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
### Motivation
- Добавить готовый Discord-бот на TypeScript, который создаёт официальный Watch Together (YouTube) invite в текущем voice-канале.
- Выполнить требования: Node.js 20+, TypeScript, `discord.js` v14+, только slash-команды и компактный UX с embed + button.
- Обеспечить базовые проверки доступа и UX: команда только в guild, пользователь в voice-канале, проверка права `Create Instant Invite` и cooldown 10 секунд.
- Подготовить проект для локального запуска и деплоя с `Dockerfile`, `docker-compose.yml` и подробным `README.md`.

### Description
- Добавлен полный проектный scaffold с `src/` файлами, `package.json`, `tsconfig.json`, `.env.example`, `Dockerfile`, `docker-compose.yml` и `README.md`.
- Реализованы slash-подкоманды `yt start`, `yt help` и `yt link` в отдельных модулях под `src/commands`, где `yt start` создаёт invite с `targetType: InviteTargetType.EmbeddedApplication` и `targetApplication: "880218394199220334"` и возвращает embed + кнопку с ссылкой на invite.
- Добавлены утилиты `src/lib/permissions.ts` для проверки права `CreateInstantInvite` и `src/lib/cooldown.ts` для пер-пользовательского cooldown в 10 секунд, а также `src/config.ts` для чтения `DISCORD_TOKEN` и `CLIENT_ID`.
- Команды регистрируются глобально через `registerCommands()` при старте, обработка ошибок и понятные эпhemeral-ответы реализованы в `src/bot.ts`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69523970490c8326801828e7d1c7e815)